### PR TITLE
Ignore empty components of file paths in torrent

### DIFF
--- a/torf/_torrent.py
+++ b/torf/_torrent.py
@@ -515,7 +515,7 @@ class Torrent():
         elif self.mode == 'multifile':
             file_sizes = []
             for info in self.metainfo['info']['files']:
-                this_path = (self.name,) + tuple(info['path'])
+                this_path = (self.name,) + tuple(c for c in info['path'] if c)
                 if this_path == path:
                     # path points to file
                     return info['length']


### PR DESCRIPTION
I came across a torrent file that (for reasons unknown) contains empty components in its file paths, and unfortunately `torf` chokes on it, even when only trying to display the torrent. To reproduce the issue, given a `foo.torrent` of a directory `foo` containing a non-empty regular file `bar`, an empty component can be inserted like this: `sed -i 's/3:bar/0:&/' foo.torrent`