### PR TITLE
Fix extremely inefficient `in` check

### DIFF
--- a/torf/_utils.py
+++ b/torf/_utils.py
@@ -392,7 +392,7 @@ class Filepath(type(pathlib.Path())):
             return os.path.join(os.getcwd(), str(path))
 
     def __eq__(self, other):
-        return self._realpath(self) == self._realpath(other)
+        return hash(self) == hash(other)
 
     def __hash__(self):
         try:

--- a/torf/_utils.py
+++ b/torf/_utils.py
@@ -392,7 +392,10 @@ class Filepath(type(pathlib.Path())):
             return os.path.join(os.getcwd(), str(path))
 
     def __eq__(self, other):
-        return hash(self) == hash(other)
+        if isinstance(other, Filepath): # use fast cached path if possible
+            return hash(self) == hash(other)
+        else:
+            return self._realpath(self) == self._realpath(other)
 
     def __hash__(self):
         try:


### PR DESCRIPTION
I have a torrent with several thousand files, and the `filter_func`'s `in` check performs `__eq__` on the `Filepath` objects. Because it doesn't use the hash cache, it performs over 30 million lstats, bringing the disk to its knees.

By using the cached hash, my torrent is constructed quickly.