### PR TITLE
Be explicit about exported modules without `__all__`

### DIFF
--- a/torf/__init__.pyi
+++ b/torf/__init__.pyi
@@ -17,7 +17,7 @@
 __version__: str = ...
 
 from ._errors import *
-from ._magnet import Magnet
-from ._stream import TorrentFileStream
-from ._torrent import Torrent
-from ._utils import File, Filepath
+from ._magnet import Magnet as Magnet
+from ._stream import TorrentFileStream as TorrentFileStream
+from ._torrent import Torrent as Torrent
+from ._utils import File as File, Filepath as Filepath


### PR DESCRIPTION
Fixes https://github.com/rndusr/torf/issues/51

Alternative to: https://github.com/rndusr/torf/pull/53

(Star imports are considered "exported" by default, so I don't need to alias them)