### PR TITLE
type annotations for metainfo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "flatbencode==0.2.*",
-    "typing_extensions>=4.0.0;python_version<'3.11'"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "flatbencode==0.2.*",
+    "typing_extensions>=4.0.0;python_version<'3.11'"
 ]
 
 [project.optional-dependencies]

--- a/torf/_torrent.pyi
+++ b/torf/_torrent.pyi
@@ -1,9 +1,10 @@
+import sys
 from collections import OrderedDict
 from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
 from re import Pattern
-from typing import Any, Callable, Literal, NotRequired, Protocol, Required, TypedDict
+from typing import Any, Callable, Literal, Protocol
 
 from _typeshed import StrPath
 from typing_extensions import Self
@@ -13,6 +14,10 @@ from ._errors import TorfError
 from ._magnet import Magnet
 from ._utils import File, Filepath, Filepaths, Files, MonitoredList, Trackers, URLs
 
+if sys.version_info < (3,11):
+    from typing_extensions import NotRequired, Required, TypedDict
+else:
+    from typing import NotRequired, Required, TypedDict
 
 class WritableBinaryStream(Protocol):
     def seek(self, offset: int, whence: int = 0) -> int: ...

--- a/torf/_torrent.pyi
+++ b/torf/_torrent.pyi
@@ -1,10 +1,9 @@
-import sys
 from collections import OrderedDict
 from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
 from re import Pattern
-from typing import Any, Callable, Literal, Protocol
+from typing import Any, Callable, Literal, NotRequired, Protocol, Required, TypedDict
 
 from _typeshed import StrPath
 from typing_extensions import Self
@@ -14,10 +13,6 @@ from ._errors import TorfError
 from ._magnet import Magnet
 from ._utils import File, Filepath, Filepaths, Files, MonitoredList, Trackers, URLs
 
-if sys.version_info < (3, 11):
-    from typing_extensions import NotRequired, Required, TypedDict
-else:
-    from typing import NotRequired, Required, TypedDict
 
 class WritableBinaryStream(Protocol):
     def seek(self, offset: int, whence: int = 0) -> int: ...

--- a/torf/_torrent.pyi
+++ b/torf/_torrent.pyi
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
 from re import Pattern
-from typing import Any, Callable, List, Literal, Protocol
+from typing import Any, Callable, Literal, Protocol
 
 from _typeshed import StrPath
 from typing_extensions import Self
@@ -35,7 +35,7 @@ DEFAULT_TORRENT_NAME: Literal["UNNAMED TORRENT"] = ...
 
 class _FilesDict(TypedDict):
     length: int
-    path: List[str]
+    path: list[str]
 
 _InfoDict = TypedDict(
     "_InfoDict",
@@ -44,7 +44,7 @@ _InfoDict = TypedDict(
         "piece length": int,
         "pieces": bytes,
         "length": NotRequired[int],
-        "files": NotRequired[List[_FilesDict]],
+        "files": NotRequired[list[_FilesDict]],
         "private": NotRequired[bool],
         "source": NotRequired[str]
     }
@@ -56,11 +56,11 @@ _MetaInfo = TypedDict(
     {
         "info": Required[_InfoDict],
         "announce": str,
-        "announce-list": List[List[str]],
+        "announce-list": list[list[str]],
         "comment": str,
         "created by": str,
         "creation date": datetime,
-        "url-list": List[str],
+        "url-list": list[str],
     },
     total=False
 )


### PR DESCRIPTION
Hello :)

Very simple little PR, took me awhile to get a sense of the structure of the metainfo object, so thought i might as well contribute some type annotations for it.

`typing_extensions` dep is for the `Required`/`NotRequired`/`total` syntax which is only in >3.11, that's necessary to model the "anything can be in there but these are the keys that are usually in there" structure of that dict.