### PR TITLE
Restore piece_size_min_default in finally block

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -430,14 +430,16 @@ def forced_piece_size(pytestconfig):
     def _forced_piece_size(piece_size):
         orig_piece_size_min = torf.Torrent.piece_size_min_default
         torf.Torrent.piece_size_min_default = piece_size
-        with mock.patch('torf.Torrent.piece_size', new_callable=mock.PropertyMock) as mock_piece_size:
-            def piece_size_setter(prop, torrent, value):
-                torrent.metainfo['info']['piece length'] = piece_size
+        try:
+            with mock.patch('torf.Torrent.piece_size', new_callable=mock.PropertyMock) as mock_piece_size:
+                def piece_size_setter(prop, torrent, value):
+                    torrent.metainfo['info']['piece length'] = piece_size
 
-            mock_piece_size.return_value = piece_size
-            mock_piece_size.__set__ = piece_size_setter
-            yield piece_size
-        torf.Torrent.piece_size_min_default = orig_piece_size_min
+                mock_piece_size.return_value = piece_size
+                mock_piece_size.__set__ = piece_size_setter
+                yield piece_size
+        finally:
+            torf.Torrent.piece_size_min_default = orig_piece_size_min
     return _forced_piece_size
 
 


### PR DESCRIPTION
forced_piece_size restores Torrent.piece_size_min_default after the with mock.patch() block. When a test raises, the exception propagates through the with block and the restore line is skipped, leaving piece_size_min_default at the test value for all subsequent tests in the same worker process

Move the restore into a try/finally to guarantee it runs regardless of whether an exception propagates

The error occurred while running CI autopkgtests for the torf package in Debian on amd64 and arm64 arches