### PR TITLE
Drop timing-sensitive sha1 count assertion

### DIFF
--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -231,6 +231,4 @@ def test_callback_raises_exception(piece_size, create_file, forced_piece_size):
 
             assert str(e.value) == 'Argh!'
             cb.assert_called_once_with(t, Path(content_path), 1, t.pieces)
-            # The pool of hashers should be stopped before all pieces are hashed
-            assert sha1_mock.call_count < t.pieces
             assert not t.is_ready


### PR DESCRIPTION
With Python 3.14, Reader and HasherPool threads start before collect() is called. For 8-byte pieces all 1000 hashes land in hash_queue before the main thread calls hash_queue.get(), so sha1_mock.call_count always equals t.pieces regardless of whether cancellation works

The error initially appeared during the CI autopkgtest run for the torf package in Debian on amd64 and arm64